### PR TITLE
Polido-v2 upgrade changes.

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -24,6 +24,16 @@
       "address": "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
       "txHash": "0xad1cea2cdd65fa98a62da89adf07fc32f16d9811f0043ae2729a54d77f2387c7",
       "kind": "transparent"
+    },
+    {
+      "address": "0xFC4795d0CEd4B027B7FbbF9929F31fC871Ad3478",
+      "txHash": "0xb52ce97a5c16ac1580bc14cfb659c1a0d440c7649e63371b4400ac1e0d4a0758",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0ad622a3631f51B884757b6Ea0Ec27a729d22C00",
+      "txHash": "0x0fb263d7d406c8e77277ad60c9e37713c247bf0b675d12b0e6554fdf5b579f2c",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -815,6 +825,304 @@
             "numberOfBytes": "20"
           },
           "t_contract(IWithdrawManagerProxy)7598": {
+            "label": "contract IWithdrawManagerProxy",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
+    },
+    "0cb432d07ea93e8e6ffcad249e3fba23daebd60f76a48e8614949816d2a97183": {
+      "address": "0xDc3d9E141889173F3667321a0CAd80aaf00Dfb0B",
+      "txHash": "0x97a80e8735c5693c485f0d3c61678f71c61206a2ef1ba103be75a4b7c4ab9e81",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "feePercentage",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_uint256",
+            "contract": "PoLidoAdapter",
+            "src": "contracts/polido/main.sol:28"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
+    },
+    "4c5e468e7bdc6899a10e7d4dbeefa5bd97347a38f7c99ea44b5b6ac8bf93c205": {
+      "address": "0x6Cf2A28918707a3dCACD63EB1dc205F66a644202",
+      "txHash": "0x264731c0e5f27e81a3d653b0213a1abd0d66416232b97ddb8d1da80c11fbccb7",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:235"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "rootTunnel",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IFxStateRootTunnel)8290",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:13"
+          },
+          {
+            "label": "withdrawManagerProxy",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_contract(IWithdrawManagerProxy)8296",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:14"
+          },
+          {
+            "label": "erc20PredicateBurnOnly",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_contract(IERC20PredicateBurnOnly)8302",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:15"
+          },
+          {
+            "label": "depositManagerProxy",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_contract(IDepositManagerProxy)8312",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:16"
+          },
+          {
+            "label": "polidoAdapter",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_contract(IPolidoAdapter)8322",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:17"
+          },
+          {
+            "label": "maticToken",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_contract(IERC20)2389",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:18"
+          },
+          {
+            "label": "childPoolFundCollector",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_address",
+            "contract": "RootPool",
+            "src": "contracts/pools/RootPool.sol:19"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IDepositManagerProxy)8312": {
+            "label": "contract IDepositManagerProxy",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IERC20)2389": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IERC20PredicateBurnOnly)8302": {
+            "label": "contract IERC20PredicateBurnOnly",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFxStateRootTunnel)8290": {
+            "label": "contract IFxStateRootTunnel",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IPolidoAdapter)8322": {
+            "label": "contract IPolidoAdapter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWithdrawManagerProxy)8296": {
             "label": "contract IWithdrawManagerProxy",
             "numberOfBytes": "20"
           },

--- a/.openzeppelin/unknown-80001.json
+++ b/.openzeppelin/unknown-80001.json
@@ -34,6 +34,16 @@
       "address": "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
       "txHash": "0xd005432d3003ed8986f9badfa36d78781e5c18d48d59f7ad65c696c4c18f026f",
       "kind": "transparent"
+    },
+    {
+      "address": "0x0ad622a3631f51B884757b6Ea0Ec27a729d22C00",
+      "txHash": "0xc089644e3ce7f08682662fb0bf7526cee34bcce668db079bc99c54bd73a43b43",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x04B2Ef48871D69418C64907c2fE60a8a062D7af9",
+      "txHash": "0x86986a10801be45720a5513e26b4c3a6b1b4260f06fb55e1aa3d830357c54da5",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -1283,6 +1293,569 @@
               }
             ],
             "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
+    },
+    "59525356db1e0496e985ec29f30343425403d9fd66b48f35588b8a9be60d9ada": {
+      "address": "0x6Cf2A28918707a3dCACD63EB1dc205F66a644202",
+      "txHash": "0x78b93ba2521db0dff8c89416938990a2f2426b8dad175909bc0cf4e1a9d5a7ef",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:235"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "childTunnel",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IFxStateChildTunnel)8225",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:16"
+          },
+          {
+            "label": "maticToken",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_contract(IMaticToken)8231",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:17"
+          },
+          {
+            "label": "stMaticToken",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_contract(IERC20)2389",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:18"
+          },
+          {
+            "label": "fundCollector",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_contract(IFundCollector)8237",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:19"
+          },
+          {
+            "label": "shuttleExpiry",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_uint256",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:20"
+          },
+          {
+            "label": "currentShuttle",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_uint256",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:21"
+          },
+          {
+            "label": "enroutedShuttle",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_uint256",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:22"
+          },
+          {
+            "label": "availableMaticBalance",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_uint256",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:23"
+          },
+          {
+            "label": "availableStMaticBalance",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_uint256",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:24"
+          },
+          {
+            "label": "fee",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_uint256",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:25"
+          },
+          {
+            "label": "feeBeneficiary",
+            "offset": 0,
+            "slot": "261",
+            "type": "t_address",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:26"
+          },
+          {
+            "label": "shuttles",
+            "offset": 0,
+            "slot": "262",
+            "type": "t_mapping(t_uint256,t_struct(Shuttle)8144_storage)",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:29"
+          },
+          {
+            "label": "balances",
+            "offset": 0,
+            "slot": "263",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:30"
+          },
+          {
+            "label": "campaign",
+            "offset": 0,
+            "slot": "264",
+            "type": "t_contract(ICampaign)8251",
+            "contract": "ChildPool",
+            "src": "contracts/pools/ChildPool.sol:32"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ICampaign)8251": {
+            "label": "contract ICampaign",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IERC20)2389": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFundCollector)8237": {
+            "label": "contract IFundCollector",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IFxStateChildTunnel)8225": {
+            "label": "contract IFxStateChildTunnel",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IMaticToken)8231": {
+            "label": "contract IMaticToken",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ShuttleStatus)8134": {
+            "label": "enum IChildPool.ShuttleStatus",
+            "members": [
+              "UNAVAILABLE",
+              "AVAILABLE",
+              "ENROUTE",
+              "ARRIVED",
+              "EXPIRED",
+              "CANCELLED"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Shuttle)8144_storage)": {
+            "label": "mapping(uint256 => struct IChildPool.Shuttle)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Shuttle)8144_storage": {
+            "label": "struct IChildPool.Shuttle",
+            "members": [
+              {
+                "label": "totalAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(ShuttleStatus)8134",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "recievedToken",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "expiry",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
+    },
+    "3a110eed14b216fc0f646e20ab6db4a994c8adf8b200f093e6f7f5bd9d12ef7f": {
+      "address": "0x8cc47De40a9084d82A3A9c43736c56534D8d244D",
+      "txHash": "0x669628b9ba37774dec0947fe85ec78f19480f88a60fd119ae284d6a75f2730e4",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:235"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "currentCampaign",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_uint256",
+            "contract": "Campaign",
+            "src": "contracts/campaign/Campaign.sol:15"
+          },
+          {
+            "label": "owner",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_address",
+            "contract": "Campaign",
+            "src": "contracts/campaign/Campaign.sol:16"
+          },
+          {
+            "label": "childPool",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_address",
+            "contract": "Campaign",
+            "src": "contracts/campaign/Campaign.sol:17"
+          },
+          {
+            "label": "campaigns",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_mapping(t_uint256,t_struct(ACampaign)3749_storage)",
+            "contract": "Campaign",
+            "src": "contracts/campaign/Campaign.sol:19"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IERC20)2389": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_enum(CampaignStatus)3701": {
+            "label": "enum ICampaign.CampaignStatus",
+            "members": [
+              "ACTIVE",
+              "PAUSED",
+              "DELETED"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(ACampaign)3749_storage)": {
+            "label": "mapping(uint256 => struct ICampaign.ACampaign)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ACampaign)3749_storage": {
+            "label": "struct ICampaign.ACampaign",
+            "members": [
+              {
+                "label": "startShuttleNum",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "endShuttleNum",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "totalRewardAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "totalClaimedAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "rewardAmountPerShuttle",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "campaignStatus",
+                "type": "t_enum(CampaignStatus)3701",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "rewardToken",
+                "type": "t_contract(IERC20)2389",
+                "offset": 1,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
           },
           "t_uint256": {
             "label": "uint256",

--- a/contracts/polido/interface.sol
+++ b/contracts/polido/interface.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.7;
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC20Upgradeable.sol";
 
 interface StMaticProxy {
-    function submit(uint256 _amount) external returns (uint256);
+    function submit(uint256 _amount, address _referral) external returns (uint256);
 
-    function requestWithdraw(uint256 _amount) external;
+    function requestWithdraw(uint256 _amount, address _referral) external;
 
     function claimTokens(uint256 _tokenId) external;
 }

--- a/contracts/polido/main.sol
+++ b/contracts/polido/main.sol
@@ -26,14 +26,20 @@ contract PoLidoAdapter is Helpers, Initializable, OwnableUpgradeable {
     );
 
     uint256 public feePercentage;
+    address public referrer;
 
     function initialize(uint256 _feePercentage) external initializer {
         feePercentage = _feePercentage;
         __Ownable_init_unchained();
+        referrer = owner();
     }
 
     function changeFeePercentage(uint256 _newFeePercentage) external onlyOwner {
         feePercentage = _newFeePercentage;
+    }
+
+    function changeReferrer(address _newReferrer) external onlyOwner {
+        referrer = _newReferrer;
     }
 
     /**
@@ -268,7 +274,7 @@ contract PoLidoAdapter is Helpers, Initializable, OwnableUpgradeable {
 
         maticToken.safeApprove(address(stMaticProxy), 0);
         maticToken.safeApprove(address(stMaticProxy), oneInchData._buyAmt);
-        uint256 stTokenAmount = stMaticProxy.submit(oneInchData._buyAmt);
+        uint256 stTokenAmount = stMaticProxy.submit(oneInchData._buyAmt, referrer);
 
         emit Deposited(
             msg.sender,
@@ -289,7 +295,7 @@ contract PoLidoAdapter is Helpers, Initializable, OwnableUpgradeable {
 
         maticToken.safeApprove(address(stMaticProxy), 0);
         maticToken.safeApprove(address(stMaticProxy), _amount);
-        uint256 stTokenAmount = stMaticProxy.submit(_amount);
+        uint256 stTokenAmount = stMaticProxy.submit(_amount, referrer);
 
         return stTokenAmount;
     }

--- a/scripts/address.js
+++ b/scripts/address.js
@@ -15,15 +15,19 @@ const addresses = {
   5: {
     checkPointManager: "0x2890bA17EfE978480615e330ecB65333b880928e",
     fxRoot: "0x3d1d3E34f7fB6D26245E6640E1c50710eFFf15bA",
-    rootTunnel: "0x9c7f7b6Bbb19876DA2767F86Eb2f280e96318EdA",
+    // v1 rootTunnel: "0x9c7f7b6Bbb19876DA2767F86Eb2f280e96318EdA",
+    rootTunnel: "0x116f7C5b58cd10340B1ab8250949C9f4b8Ca54Ce", // v2
     withdrawManagerProxy: "0x2923C8dD6Cdf6b2507ef91de74F1d5E0F11Eac53",
     erc20PredicateBurnOnly: "0xf213e8fF5d797ed2B052D3b96C11ac71dB358027",
     depositManagerProxy: "0x7850ec290A2e2F40B82Ed962eaf30591bb5f5C96",
-    poLidoAdapter: "0xf8bb8087F9967Edf6B0D26D146fA978A953EC2A5",
+    // v1 poLidoAdapter: "0xf8bb8087F9967Edf6B0D26D146fA978A953EC2A5",
+    poLidoAdapter: "0xFC4795d0CEd4B027B7FbbF9929F31fC871Ad3478", // v2
     maticToken: "0x499d11e0b6eac7c0593d8fb292dcbbf815fb29ae",
-    childPoolFundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80",
+    // v1 childPoolFundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80",
+    childPoolFundCollector: "0x253a0b47bf8e82C540903d240C1E4113F303D230",
     rootPoolOwner: "0x0C170Dc2D2537FaDFdB2b374c3141bBb4ADDb1f7",
-    rootPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
+    // v1 rootPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
+    rootPoolProxy: "0x0ad622a3631f51B884757b6Ea0Ec27a729d22C00", // v2
   },
   137: {
     fxChild: "0x8397259c983751DAf40400790063935a11afa28a",
@@ -39,15 +43,18 @@ const addresses = {
   },
   80001: {
     fxChild: "0xCf73231F28B7331BBe3124B907840A94851f9f11",
-    childTunnel: "0x55Cc891d4B2BBc6ea70CDBF874c549641A5D3194",
+    // v1 childTunnel: "0x55Cc891d4B2BBc6ea70CDBF874c549641A5D3194",
+    childTunnel: "0x28347DEC3770c244d440Ba3e87Cd53fC0E7FC86C", // v2
     maticTokenOnChild: "0x0000000000000000000000000000000000001010",
     stMaticToken: "0xa337f0B897a874DE1E9F75944629a03F911cFbE8",
-    fundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80",
+    // fundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80" v1,
+    fundCollector: "0x253a0b47bf8e82C540903d240C1E4113F303D230", // v2
     fee: 500,
     shuttleExpiry: 10,
     feeBeneficiary: "0x0C170Dc2D2537FaDFdB2b374c3141bBb4ADDb1f7",
     childPoolOwner: "0x0C170Dc2D2537FaDFdB2b374c3141bBb4ADDb1f7",
-    childPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
+    // v1 childPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
+    childPoolProxy: "0x0ad622a3631f51B884757b6Ea0Ec27a729d22C00", // v2
   },
 };
 

--- a/scripts/address.js
+++ b/scripts/address.js
@@ -15,19 +15,19 @@ const addresses = {
   5: {
     checkPointManager: "0x2890bA17EfE978480615e330ecB65333b880928e",
     fxRoot: "0x3d1d3E34f7fB6D26245E6640E1c50710eFFf15bA",
-    // v1 rootTunnel: "0x9c7f7b6Bbb19876DA2767F86Eb2f280e96318EdA",
     rootTunnel: "0x116f7C5b58cd10340B1ab8250949C9f4b8Ca54Ce", // v2
     withdrawManagerProxy: "0x2923C8dD6Cdf6b2507ef91de74F1d5E0F11Eac53",
     erc20PredicateBurnOnly: "0xf213e8fF5d797ed2B052D3b96C11ac71dB358027",
     depositManagerProxy: "0x7850ec290A2e2F40B82Ed962eaf30591bb5f5C96",
-    // v1 poLidoAdapter: "0xf8bb8087F9967Edf6B0D26D146fA978A953EC2A5",
     poLidoAdapter: "0xFC4795d0CEd4B027B7FbbF9929F31fC871Ad3478", // v2
     maticToken: "0x499d11e0b6eac7c0593d8fb292dcbbf815fb29ae",
-    // v1 childPoolFundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80",
     childPoolFundCollector: "0x253a0b47bf8e82C540903d240C1E4113F303D230",
     rootPoolOwner: "0x0C170Dc2D2537FaDFdB2b374c3141bBb4ADDb1f7",
-    // v1 rootPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
     rootPoolProxy: "0x0ad622a3631f51B884757b6Ea0Ec27a729d22C00", // v2
+    // v1 rootTunnel: "0x9c7f7b6Bbb19876DA2767F86Eb2f280e96318EdA",
+    // v1 poLidoAdapter: "0xf8bb8087F9967Edf6B0D26D146fA978A953EC2A5",
+    // v1 childPoolFundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80",
+    // v1 rootPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
   },
   137: {
     fxChild: "0x8397259c983751DAf40400790063935a11afa28a",
@@ -43,18 +43,18 @@ const addresses = {
   },
   80001: {
     fxChild: "0xCf73231F28B7331BBe3124B907840A94851f9f11",
-    // v1 childTunnel: "0x55Cc891d4B2BBc6ea70CDBF874c549641A5D3194",
     childTunnel: "0x28347DEC3770c244d440Ba3e87Cd53fC0E7FC86C", // v2
     maticTokenOnChild: "0x0000000000000000000000000000000000001010",
     stMaticToken: "0xa337f0B897a874DE1E9F75944629a03F911cFbE8",
-    // fundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80" v1,
     fundCollector: "0x253a0b47bf8e82C540903d240C1E4113F303D230", // v2
     fee: 500,
     shuttleExpiry: 10,
     feeBeneficiary: "0x0C170Dc2D2537FaDFdB2b374c3141bBb4ADDb1f7",
     childPoolOwner: "0x0C170Dc2D2537FaDFdB2b374c3141bBb4ADDb1f7",
-    // v1 childPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
     childPoolProxy: "0x0ad622a3631f51B884757b6Ea0Ec27a729d22C00", // v2
+    // v1 childTunnel: "0x55Cc891d4B2BBc6ea70CDBF874c549641A5D3194",
+    // v1 childPoolProxy: "0x307DdD8c382B92c81a1a1750C47D8Aa84b774Cf5",
+    // v1 fundCollector: "0x346EdB63a433405fc4411462a86acEa25fDeef80",
   },
 };
 


### PR DESCRIPTION
- Updated stMaticProxy interface methods to have an additional `address _referral` parameter.
- Added a public storage variable `address referrer`.
- Added a public owner only accessible method to change referrer.
- Passed additional `referrer` to all `stMaticProxy.submit()` calls.